### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Grab the files from one of the CDNs and include them in your page:
 
 //or
 
-<link href="https://cdn.jsdelivr.net/gh/mobius1/vanilla-Datatables@latest/dist/vanilla-dataTables.min.css" rel="stylesheet" type="text/css">
-<script src="https://cdn.jsdelivr.net/gh/mobius1/vanilla-Datatables@latest/dist/vanilla-dataTables.min.js" type="text/javascript"></script>
+<link href="https://cdn.jsdelivr.net/npm/vanilla-datatables@latest/dist/vanilla-dataTables.min.css" rel="stylesheet" type="text/css">
+<script src="https://cdn.jsdelivr.net/npm/vanilla-datatables@latest/dist/vanilla-dataTables.min.js" type="text/javascript"></script>
 ```
 
 You can replace `latest` with the required release number.


### PR DESCRIPTION
While our new back-end supports serving files from both npm and GitHub, we recommend always using only one of these methods for every package, with npm being the preferred one (using only npm means you can get detailed package usage statistics and npm packages are also searchable on our website).

I updated the links to use our npm endpoint.

Feel free to ping me if you have any questions regarding this change.