### PR TITLE
Updates export check order

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -10,10 +10,10 @@
 (function (root, factory) {
     var plugin = "DataTable";
 
-    if (typeof define === "function" && define.amd) {
-        define([], factory(plugin));
-    } else if (typeof exports === "object") {
+    if (typeof exports === "object") {
         module.exports = factory(plugin);
+    } else if (typeof define === "function" && define.amd) {
+        define([], factory(plugin));
     } else {
         root[plugin] = factory(plugin);
     }


### PR DESCRIPTION
I was facing a similar issue as #34 when loading as an ES6 module using `import DataTables from 'vanilla-datatables'` syntax using webpack. Changing the check order allowed me to load it without a problem.