### PR TITLE
Update vanilla-dataTables.js

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -11,7 +11,7 @@
     var plugin = "DataTable";
 
     if (typeof exports === "object") {
-        modules.exports = factory(plugin);
+        module.exports = factory(plugin);
     } else if (typeof define === "function" && define.amd) {
         define([], factory(plugin));
     } else {


### PR DESCRIPTION
Fix modules not defined error.  Extra "s" in there, sorry about that.