### PR TITLE
Allow sort by data attribute

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -1824,12 +1824,17 @@
 
             // https://github.com/Mobius1/Vanilla-DataTables/issues/12
             var doesQueryMatch = query.split(" ").reduce(function (bool, word) {
-                var includes = false;
+                var includes = false,
+                    cell = null,
+                    content = null;
 
                 for (var x = 0; x < row.cells.length; x++) {
+                    cell = row.cells[x];
+                    content = cell.hasAttribute('data-content') ? cell.getAttribute('data-content') : cell.textContent;
+
                     if (
-                        row.cells[x].textContent.toLowerCase().indexOf(word) > -1 &&
-                        that.columns(row.cells[x].cellIndex).visible()
+                        content.toLowerCase().indexOf(word) > -1 &&
+                        that.columns(cell.cellIndex).visible()
                     ) {
                         includes = true;
                         break;

--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -698,7 +698,7 @@
 
         each(rows, function (tr) {
             var cell = tr.cells[column];
-            var content = cell.data;
+            var content = cell.hasAttribute('data-content') ? cell.getAttribute('data-content') : cell.data;
             var num = content.replace(/(\$|\,|\s|%)/g, "");
 
             // Check for date format and moment.js


### PR DESCRIPTION
We're using `cell.data` as value for sorting.

This isn't optimal when we have links or images inside the cells.

With this PR we can optionally set `data-content` on the `<td>` and use that value to sort.