### PR TITLE
Fix shared options between instances of DataTables

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -27,7 +27,8 @@
      * Default configuration
      * @typ {Object}
      */
-    var defaultConfig = {
+    function defaultConfig() {
+      return {
         perPage: 10,
         perPageSelect: [5, 10, 15, 20, 25],
 
@@ -66,7 +67,8 @@
             top: "{select}{search}",
             bottom: "{info}{pager}"
         }
-    };
+      };
+    }
 
     /**
      * Check is item is object
@@ -951,7 +953,7 @@
         this.initialized = false;
 
         // user options
-        this.options = extend(defaultConfig, options);
+        this.options = extend(defaultConfig(), options);
 
         if (typeof table === "string") {
             table = document.querySelector(table);


### PR DESCRIPTION
## Summary
When using multiple data tables in a HTML, it seems that options for each instances are shared.
I discover it is because of the ｀defaultConfig｀ object is broken changed when creating DataTable instances.

## Example
```js
var myData = {
    "headings": [
        "Name",
        "Company",
        "Ext.",
        "Start Date",
        "Email",
        "Phone No."
    ],
    "data": [
        [
            "Hedwig F. Nguyen",
            "Arcu Vel Foundation",
            "9875",
            "03/27/2017",
            "nunc.ullamcorper@metusvitae.com",
            "070 8206 9605"
        ],
        [
            "Genevieve U. Watts",
            "Eget Incorporated",
            "9557",
            "07/18/2017",
            "Nullam.vitae@egestas.edu",
            "0800 106980"
        ],
    ]
};

var table1 = new DataTable("#dt1", { data: myData, perPage: 25 });
var table2 = new DataTable("#dt2", { });
```

### Expected
* `table1` has set default perPage = 25.
* `table2` has set default perPage = 10(default).
* `table1` has 2 records.
* `table2` has no records.

### Actual(before fixed by this PR)
* `table1` has set default perPage = 25.
* `table2` has set default perPage = 25.
* `table1` has 2 records.
* `table2` has 2 records.
