### PR TITLE
Fix: Columns rebuild row.cloneNode: TD's duplicated (TD²)

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -796,8 +796,8 @@
 
         // Loop over the rows and reorder the cells
         each(dt.data, function (row, i) {
-            a = row.cloneNode();
-            b = row.cloneNode();
+            a = row.cloneNode(false);
+            b = row.cloneNode(false);
 
             a.dataIndex = b.dataIndex = i;
 
@@ -811,9 +811,9 @@
                 c.data = cell.data;
                 a.appendChild(c);
 
-                if (dt.hiddenColumns.indexOf(cell.cellIndex) < 0) {
-                    d = cell.cloneNode(true);
-                    d.data = cell.data;
+                if (dt.hiddenColumns.indexOf(c.cellIndex) < 0) {
+                    d = c.cloneNode(true);
+                    d.data = c.data;
                     b.appendChild(d);
                 }
             });
@@ -846,7 +846,7 @@
      * @return {HTMLElement}
      */
     Rows.prototype.build = function (row) {
-        var td, tr = createElement("tr");
+        var tr = createElement("tr");
 
         var headings = this.dt.headings;
 
@@ -857,7 +857,7 @@
         }
 
         each(headings, function (h, i) {
-            td = createElement("td");
+            var td = createElement("td");
 
             // Fixes #29
             if (!row[i] && !row[i].length) {


### PR DESCRIPTION
After few hours to solve mystery "doublons" and
sort don't work in my old Chomium browser ( chromium.31)

Test with other version Same result (2.0.0.a23, 1.6.10,) and ...
In v1.2.2 nothing TDs duplicated on init but atfer sorting yes ;)

Forward to Present ... And
After more tests & logs for find where TD is duplicated

In dataTable vanilla Columns.prototype.rebuild
Before // Loop over the rows and reorder the cells
 dt.data are ok
but after each() : a & b clones TD is duplicated!

Only cloneNode(false) remove dublicated TDs
chrome: default param deep is false (maybe not)
Tested with true (TDs duplicated)
https://developer.mozilla.org/fr/docs/Web/API/Node/cloneNode

Rest of update code seems more speedy, with src file :)

##Info

Solve my problems callback modify td content in event : sort
 dataTable.on('datatable.'+events
i use events init, refresh & sort

just an impression or lost important data?

cell -> c is maybe more logic for chain object?
It's just an intiuition, but if possible not (used in a test).
work fine with no doublons with original code
```
                if (dt.hiddenColumns.indexOf(cell.cellIndex) < 0) {
                    d = cell.cloneNode(true);
                    d.data = cell.data;
```

Why td create an element tr & then unused before each()?
probably oups :)
work fine with no doublons with original code
```
var td, tr = createElement("tr");
```

In One moment Chromium say : data is undefined
in Columns.prototype.sort
 var content ...  cell.data is undefined : Chromium 31
 && test with cell.innertext is undefined in Firefox 43

I have used this to solve the trouble
```
var content = cell.hasAttribute('data-content') ? cell.getAttribute
('data-content') : cell.data;
```
replaced by
```
var content = cell.hasAttribute('data-content') ?  cell.getAttribute
('data-content') : cell.data || cell.textContent ||
cell.innerText;//CrossBrowser Fix
```
[MDN textContent](https://developer.mozilla.org/en-
US/docs/Web/API/Node/textContent)

But,
with this update, now, all work fine in all levels, but why? :D

Tested ok with QUnit:
 Firefox 43 & 59
  Mozilla/5.0 (X11; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0
  Mozilla/5.0 (X11; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0
 Chromium 31 ;)
  Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
Chrome/31.0.1650.63 Safari/537.36