### PR TITLE
manually encode "#" when exporting to csv

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -2085,6 +2085,8 @@
                                 text = text.replace(/\s{2,}/g, ' ');
                                 text = text.replace(/\n/g, '  ');
                                 text = text.replace(/"/g, '""');
+                                //have to manually encode "#" as encodeURI leaves it as is.
+                                text = text.replace(/#/g, "%23");
                                 if (text.indexOf(",") > -1)
                                     text = '"' + text + '"';
 


### PR DESCRIPTION
in firefox, if the csv data has a "#" in it, the file ends at the index of the first occurrence. additionally, encodeURI doesn't encode "#" since it's a valid uri character.