### PR TITLE
Fix for the fix for #29: handle null/undefined cells

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -860,7 +860,7 @@
             td = createElement("td");
 
             // Fixes #29
-            if (!row[i] && !row[i].length) {
+            if (!row[i] || !row[i].length) {
                 row[i] = "";
             }
 


### PR DESCRIPTION
The fix for #29 has improper boolean logic.  The result is that datatables can't handle undefined cell data.