### PR TITLE
Wrong pagination message.

### DIFF
--- a/src/vanilla-dataTables.js
+++ b/src/vanilla-dataTables.js
@@ -1860,9 +1860,9 @@
             classList.remove(that.wrapper, "search-results");
 
             that.setMessage(that.options.labels.noRows);
-        } else {
-            that.update();
         }
+
+        that.update();
 
         this.emit("datatable.search", query, this.searchData);
     };


### PR DESCRIPTION
We will update the chart even if there are no search results so that the pagination message changes. Otherwise it shows the wrong pagination message.